### PR TITLE
Add possibility to hide indexes on leaf arrays

### DIFF
--- a/src/jsonToFormData.js
+++ b/src/jsonToFormData.js
@@ -29,7 +29,18 @@
         return !isArray(val) && typeof val === 'object' && !!val;
     }
 
-    function convert(jsonObject, parentKey, carryFormData) {
+    function merge(object1, object2) {
+        object2 = object2 || {}
+        return [object1, object2]
+            .reduce(function (r, o) {
+                Object.keys(o).forEach(function (k) {
+                    r[k] = o[k];
+                });
+                return r;
+            }, {});
+    }
+
+    function doConvert(jsonObject, parentKey, carryFormData, options) {
 
         var formData = carryFormData || new FormData();
 
@@ -50,7 +61,11 @@
 
                     if (parentKey && isArray(jsonObject)) {
 
-                        propName = parentKey + '[' + index + ']';
+                        index_string = ''
+                        if (isArray(jsonObject[key]) || isObject(jsonObject[key]) || options.showLeafArrayIndexes ) {
+                            index_string = index
+                        }
+                        propName = parentKey + '[' + index_string + ']';
                     }
 
                     if (jsonObject[key] instanceof File) {
@@ -66,7 +81,7 @@
 
                     } else if (isArray(jsonObject[key]) || isObject(jsonObject[key])) {
 
-                        convert(jsonObject[key], propName, formData);
+                        doConvert(jsonObject[key], propName, formData, options);
 
                     } else if (typeof jsonObject[key] === 'boolean') {
 
@@ -83,6 +98,16 @@
         }
 
         return formData;
+    }
+
+    function convert(jsonObject, options) {
+        var defaultOptions = {
+            showLeafArrayIndexes: true,
+        };
+
+        options = merge(defaultOptions, options);
+
+        return doConvert(jsonObject, undefined, undefined, options);
     }
 
     return convert;

--- a/tests/jsonToFormData.js
+++ b/tests/jsonToFormData.js
@@ -1,3 +1,11 @@
+function logFormData(formData) {
+    console.log('=========');
+    for(var pair of formData.entries()) {
+        console.log(pair[0]+ ' => '+ pair[1]);
+    }
+    console.log('^^^^^^^^^');
+}
+
 describe('jsonToFormData', function() {
 
     it('should be attached to the window', function() {
@@ -48,6 +56,20 @@ describe('jsonToFormData', function() {
         expect(formDataResult.get('prop1[1]')).to.equal('test');
         expect(formDataResult.get('prop1[2]')).to.equal('1');
         expect(formDataResult.get('prop1[3]')).to.equal('0');
+    });
+
+    it('should convert arrays without showing indexes on simple arrays', function() {
+
+        var testObject = {
+            prop1: [11, 'test', true, false]
+        };
+
+        var formDataResult = window.jsonToFormData(testObject, {showLeafArrayIndexes: false});
+
+        expect(formDataResult.getAll('prop1[]')[0]).to.equal('11');
+        expect(formDataResult.getAll('prop1[]')[1]).to.equal('test');
+        expect(formDataResult.getAll('prop1[]')[2]).to.equal('1');
+        expect(formDataResult.getAll('prop1[]')[3]).to.equal('0');
     });
 
     it('should convert a shallow object', function() {
@@ -191,6 +213,51 @@ describe('jsonToFormData', function() {
         expect(formDataResult.get('prop7[0][prop2]')).to.equal('2');
         expect(formDataResult.get('prop7[0][prop5]')).to.equal('1');
         expect(formDataResult.get('prop7[0][prop6]')).to.equal('0');
+
+        expect(formDataResult.get('prop7[1][prop1]')).to.equal('another_test');
+        expect(formDataResult.get('prop7[1][prop2]')).to.equal('3');
+        expect(formDataResult.get('prop7[1][prop5]')).to.equal('0');
+        expect(formDataResult.get('prop7[1][prop6]')).to.equal('1');
+    });
+
+    it('should convert an array of objects and for simple arrays not display indexes', function() {
+
+        var testObject = {
+            prop1: 'test',
+            prop2: 2,
+            prop3: null,
+            prop4: undefined,
+            prop5: true,
+            prop6: false,
+            prop7: [{
+                prop1: 'test',
+                prop2: 2,
+                prop3: null,
+                prop4: undefined,
+                prop5: true,
+                prop6: false,
+                prop7: [11, 'test', true, false]
+            }, {
+                prop1: 'another_test',
+                prop2: 3,
+                prop3: null,
+                prop4: undefined,
+                prop5: false,
+                prop6: true
+            }]
+        };
+
+        var formDataResult = window.jsonToFormData(testObject, {showLeafArrayIndexes: false});
+
+        expect(formDataResult.get('prop7[0][prop1]')).to.equal('test');
+        expect(formDataResult.get('prop7[0][prop2]')).to.equal('2');
+        expect(formDataResult.get('prop7[0][prop5]')).to.equal('1');
+        expect(formDataResult.get('prop7[0][prop6]')).to.equal('0');
+
+        expect(formDataResult.getAll('prop7[0][prop7][]')[0]).to.equal('11');
+        expect(formDataResult.getAll('prop7[0][prop7][]')[1]).to.equal('test');
+        expect(formDataResult.getAll('prop7[0][prop7][]')[2]).to.equal('1');
+        expect(formDataResult.getAll('prop7[0][prop7][]')[3]).to.equal('0');
 
         expect(formDataResult.get('prop7[1][prop1]')).to.equal('another_test');
         expect(formDataResult.get('prop7[1][prop2]')).to.equal('3');


### PR DESCRIPTION
Hi @hyperatom,

was wondering if you'd accept this PR that provide the possibility to not inline indexes of simple arrays in  formData keys ? (arrays of objects, or arrays of arrays are not affected as you can see in the tests)

### Actual default behavior remains unchanged

```js
jsonToFormData({
  prop: [
    'test',
    2,
  ]
})
```

Gives the following multipart/formdata

```
prop[0]
test

prop[1]
2
```

# New behavior
a new `showLeafArrayIndexes` option would be added
```js
jsonToFormData({
  prop: [
    'test',
    2,
  ]
}, { showLeafArrayIndexes: false })
```
Now we'll have the following multipart/formdata

```
prop[]
test

prop[]
2
```
